### PR TITLE
Fixing a mixup of yaw and pitch in the coding example of third-person.md

### DIFF
--- a/docs/follow-modes/third-person.md
+++ b/docs/follow-modes/third-person.md
@@ -313,11 +313,11 @@ pcam.get_third_person_rotation_degrees()
 ```gdscript
 var mouse_sensitivity: float = 0.05
 
-var min_yaw: float = -89.9
-var max_yaw: float = 50
+var min_yaw: float = 0
+var max_yaw: float = 360
 
-var min_pitch: float = 0
-var max_pitch: float = 360
+var min_pitch: float = -89.9
+var max_pitch: float = 50
 
 func _unhandled_input(event) -> void:
   # Trigger whenever the mouse moves.
@@ -331,13 +331,13 @@ func _unhandled_input(event) -> void:
     pcam_rotation_degrees.x -= event.relative.y * mouse_sensitivity
 		
     # Clamp the rotation in the X axis so it can go over or under the target.
-    pcam_rotation_degrees.x = clampf(pcam_rotation_degrees.x, min_yaw, max_yaw)
+    pcam_rotation_degrees.x = clampf(pcam_rotation_degrees.x, min_pitch, max_pitch)
 
     # Change the Y rotation value.
     pcam_rotation_degrees.y -= event.relative.x * mouse_sensitivity
 		
     # Sets the rotation to fully loop around its target, but without going below or exceeding 0 and 360 degrees respectively.
-    pcam_rotation_degrees.y = wrapf(pcam_rotation_degrees.y, min_pitch, max_pitch)
+    pcam_rotation_degrees.y = wrapf(pcam_rotation_degrees.y, min_yaw, max_yaw)
 		
     # Change the SpringArm3D node's rotation and rotate around its target.
     pcam.set_third_person_rotation_degrees(pcam_rotation_degrees)


### PR DESCRIPTION
The coding Example Setup mixed up the x and y axis names as it relates to yaw and pitch. Rotating around the x axis is in fact a pitching motion, not a yaw.

Rotating around the y axis is conversely a yaw, not a pitch.